### PR TITLE
Update Makefile (ISO/IEC 9899:1999)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: inject sample
 
 inject: inject.c
-	gcc inject.c -Wall -Wextra -o inject
+	gcc inject.c -Wall -Wextra -o inject -std=c99
 
 sample: sample-process/sample.c
-	gcc sample-process/sample.c -o sample-process/sample
+	gcc sample-process/sample.c -o sample-process/sample -std=c99
 
 clean: 
 	rm -f inject sample-process/sample


### PR DESCRIPTION
Some distros like RedHat or Centos do not implement by default the ISO c99 mode in the gcc compiler. Therefore when compiling the proof of concept it shows errors on all lines where the variable was defined inside a loop. Adding this parameter will help it compile on all GNU/Linux distributions.